### PR TITLE
Update network description comment in TRNet.py

### DIFF
--- a/src/DeepNetworks/TRNet.py
+++ b/src/DeepNetworks/TRNet.py
@@ -1,4 +1,4 @@
-""" Pytorch implementation of TRNet, a neural network for multi-frame super resolution (MFSR) by recursive fusion. """
+""" Pytorch implementation of TRNet, a neural network for multi-frame super resolution (MFSR) by transformer fusion. """
 
 import torch
 import torch.nn.functional as F
@@ -196,7 +196,7 @@ class Decoder(nn.Module):
         return x
 
 class TRNet(nn.Module):
-    ''' TRNet, a neural network for multi-frame super resolution (MFSR) by recursive fusion. '''
+    ''' TRNet, a neural network for multi-frame super resolution (MFSR) by transformer fusion. '''
 
     def __init__(self, config):
         '''


### PR DESCRIPTION
# Problem
The current description states that `TRNet` uses a recursive fusion module, while the implementation uses a transformer-based fusion module. 

## Solution
Update description comment.